### PR TITLE
Switch the order of the screencasts in the react example

### DIFF
--- a/react/react-widget/README.md
+++ b/react/react-widget/README.md
@@ -4,7 +4,7 @@
 
 This extension shows how to use the `ReactWidget` wrapper from `@jupyterlab/apputils` to use React in a JupyterLab extension.
 
-![react-widget](preview.gif)
+![react-widget](preview2.gif)
 
 ## Install
 
@@ -32,4 +32,4 @@ jupyter lab --watch
 
 It is possible to use the [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=de) Chrome extension to inspect React components.
 
-![react-dev-tools](preview2.gif)
+![react-dev-tools](preview.gif)


### PR DESCRIPTION
So it shows the react dev tools under the `React Developer Tools` section of the README.

https://github.com/jupyterlab/extension-examples/blob/b5118da064f9e3e1eb51d73d9778b17ba5cb42d1/react/react-widget/README.md