### PR TITLE
Remove references to context menu

### DIFF
--- a/command-palette/README.md
+++ b/command-palette/README.md
@@ -76,5 +76,4 @@ appear in the web browser console after clicking on the command in the palette.
 A command can be triggered by other UI elements:
 
 - Add the command to a [menu](../../main-menu/README.md)
-- Add the command to a [context menu](../../context-menu/README.md)
 - Add the command to the [launcher](../../launcher/README.md)

--- a/commands/README.md
+++ b/commands/README.md
@@ -93,5 +93,4 @@ card or the command palette to be easily triggered by the user.
 
 - Add the command to the [command palette](../command-palette/README.md)
 - Add the command to a [menu](../main-menu/README.md)
-- Add the command to a [context menu](../context-menu/README.md)
 - Add the command to the [launcher](../launcher/README.md)

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -112,4 +112,3 @@ know more about those other possible, you could look at the following examples:
 
 - Add the command to the [command palette](../command-palette/README.md)
 - Add the command to a [menu](../main-menu/README.md)
-- Add the command to a [context menu](../context-menu/README.md)

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,6 @@
     "basics/*",
     "commands",
     "command-palette",
-    "context-menu/*",
     "keyboard-shortcuts/*",
     "launcher",
     "left-right-areas/*",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
       "basics/*",
       "commands",
       "command-palette",
-      "context-menu/*",
       "keyboard-shortcuts/*",
       "launcher",
       "left-right-areas/*",


### PR DESCRIPTION
There is no context menu example yet, but we should eventually add one.
