### PR TITLE
Use stable JupyterLab on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install the Python dependencies
-      run: python -m pip install jupyterlab --pre
+      run: python -m pip install jupyterlab
     - name: Install the NPM dependencies
       run: |
         cd ${EXAMPLE_FOLDER}
@@ -102,7 +102,7 @@ jobs:
     - name: Install the Python dependencies
       run: |
         python -m pip install jupyter_packaging
-        python -m pip install jupyterlab --pre
+        python -m pip install jupyterlab
     - name: Install the NPM dependencies
       run: |
         cd advanced/server-extension
@@ -166,7 +166,7 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install the Python dependencies
-      run: python -m pip install jupyterlab --pre
+      run: python -m pip install jupyterlab
     - name: Bootstrap the jlpm deps
       run: jlpm
     - name: Build all the extensions


### PR DESCRIPTION
Similar change as in https://github.com/jupyterlab/extension-cookiecutter-ts/pull/68.

This uses the latest stable lab instead of install the pre-release.