### PR TITLE
Add an icon to the react widget

### DIFF
--- a/react/react-widget/src/index.ts
+++ b/react/react-widget/src/index.ts
@@ -37,6 +37,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         const content = new CounterWidget();
         const widget = new MainAreaWidget<CounterWidget>({ content });
         widget.title.label = 'React Widget';
+        widget.title.icon = reactIcon;
         app.shell.add(widget, 'main');
       }
     });


### PR DESCRIPTION
See https://github.com/jupyterlab/extension-examples/issues/126 and https://github.com/jupyterlab/jupyterlab/pull/9092


![image](https://user-images.githubusercontent.com/591645/94536089-a1c3e880-0242-11eb-839b-8532720074bf.png)
