### PR TITLE
Fixed Typo in heading

### DIFF
--- a/state/README.md
+++ b/state/README.md
@@ -1,4 +1,4 @@
-# Sate
+# State
 
 > Use State persistence in an extension.
 


### PR DESCRIPTION
Have fixed the Typo in the heading of the readme file.