### PR TITLE
'extension' to 'plugin' in README

### DIFF
--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -130,8 +130,8 @@ of the `JupyterFrontEndPlugin` class:
 ```ts
 // src/index.ts#L9-L12
 
-const extension: JupyterFrontEndPlugin<void> = {
-  id: 'hello-world',
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'hello-world:plugin',
   autoStart: true,
   activate: (app: JupyterFrontEnd) => {
 ```
@@ -146,7 +146,7 @@ const extension: JupyterFrontEndPlugin<void> = {
   }
 };
 
-export default extension;
+export default plugin;
 ```
 <!-- prettier-ignore-end -->
 
@@ -163,7 +163,7 @@ point into the extension. In this example, it calls the `console.log` function t
 something into the browser developer tools console.
 
 Your new `JupyterFrontEndPlugin` instance has to be finally exported to be visible to
-JupyterLab, which is done with the line `export default extension`.
+JupyterLab, which is done with the line `export default plugin`.
 
 Now that the extension code is ready, you need to install it within JupyterLab.
 

--- a/hello-world/src/index.ts
+++ b/hello-world/src/index.ts
@@ -6,7 +6,7 @@ import {
 /**
  * Initialization data for the hello-world extension.
  */
-const extension: JupyterFrontEndPlugin<void> = {
+const plugin: JupyterFrontEndPlugin<void> = {
   id: 'hello-world',
   autoStart: true,
   activate: (app: JupyterFrontEnd) => {
@@ -14,4 +14,4 @@ const extension: JupyterFrontEndPlugin<void> = {
   }
 };
 
-export default extension;
+export default plugin;

--- a/hello-world/src/index.ts
+++ b/hello-world/src/index.ts
@@ -7,7 +7,7 @@ import {
  * Initialization data for the hello-world extension.
  */
 const plugin: JupyterFrontEndPlugin<void> = {
-  id: 'hello-world',
+  id: 'hello-world:plugin',
   autoStart: true,
   activate: (app: JupyterFrontEnd) => {
     console.log('the JupyterLab main application:', app);


### PR DESCRIPTION
Match template changes from https://github.com/jupyterlab/extension-cookiecutter-ts/pull/156