### PR TITLE
Pin nodejs version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - jupyter-packaging>=0.10.0,<2
   - jupyterlab=3
-  - nodejs
+  - nodejs=16
   - pytest
   - pytest-check-links
   - python=3


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

This addresses an issue seen in #192 where the following warning surfaces:

```bash
    npm WARN EBADENGINE Unsupported engine {
    npm WARN EBADENGINE   package: 'eslint-plugin-jsdoc@36.1.1',
    npm WARN EBADENGINE   required: { node: '^12 || ^14 || ^16' },
    npm WARN EBADENGINE   current: { node: 'v17.8.0', npm: '8.5.5' }
    npm WARN EBADENGINE }
    npm WARN EBADENGINE Unsupported engine {
    npm WARN EBADENGINE   package: '@es-joy/jsdoccomment@0.10.8',
    npm WARN EBADENGINE   required: { node: '^12 || ^14 || ^16' },
    npm WARN EBADENGINE   current: { node: 'v17.8.0', npm: '8.5.5' }
    npm WARN EBADENGINE }
```

..before the installations fails. Adding the version pin seems to fix it.