### PR TITLE
Inherit from jupyter_server rather than notebook

### DIFF
--- a/server-extension/jlab_ext_example/handlers.py
+++ b/server-extension/jlab_ext_example/handlers.py
@@ -1,8 +1,8 @@
 import os
 import json
 
-from notebook.base.handlers import APIHandler
-from notebook.utils import url_path_join
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.utils import url_path_join
 
 import tornado
 from tornado.web import StaticFileHandler


### PR DESCRIPTION
Ensures the examples will work without Notebookv6 or NBClassic 
Closes #209