### PR TITLE
fix: typos in README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ Add a configurable CodeMirror extension.
 
 Extend the main app with a Command.
 
-[![Commmand example](commands/preview.png)](commands)
+[![Command example](commands/preview.png)](commands)
 
 ### [Command Palette](command-palette)
 
 Register commands in the Command Palette.
 
-[![Commmand Palette](command-palette/preview.png)](command-palette)
+[![Command Palette](command-palette/preview.png)](command-palette)
 
 ### [Completer](completer)
 
@@ -197,7 +197,7 @@ Interact with a kernel from an extension.
 
 ### [Kernel Output](kernel-output)
 
-Render kernel messages in an OuputArea.
+Render kernel messages in an OutputArea.
 
 [![OutputArea class](kernel-output/preview.gif)](kernel-output)
 

--- a/kernel-output/README.md
+++ b/kernel-output/README.md
@@ -1,6 +1,6 @@
 # Kernel Output
 
-> Render kernel messages in an _OuputArea_.
+> Render kernel messages in an _OutputArea_.
 
 - [Code structure](#code-structure)
 - [Initializing a Kernel Session](#initializing-a-kernel-session)


### PR DESCRIPTION
**PR Summary**:
The PR contains a few fixes to typos found in the README.md files.