### PR TITLE
Added provider-consumer example (multiple related packages).

### DIFF
--- a/compat_4a/.copier-answers.yml
+++ b/compat_4a/.copier-answers.yml
@@ -1,0 +1,15 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+_commit: v4.2.0
+_src_path: https://github.com/jupyterlab/extension-template
+author_email: me@test.com
+author_name: My Name
+has_binder: false
+has_settings: false
+kind: frontend
+labextension_name: step_counter
+project_short_description: Adds a step counter/button, and a step increment provider
+    (1 of 3 related examples). This extension holds a provider token.
+python_name: step_counter
+repository: ''
+test: true
+

--- a/compat_4a/.copier-answers.yml
+++ b/compat_4a/.copier-answers.yml
@@ -7,8 +7,8 @@ has_binder: false
 has_settings: false
 kind: frontend
 labextension_name: step_counter
-project_short_description: Adds a step counter/button, and a step increment provider
-    (1 of 3 related examples). This extension holds a provider token.
+project_short_description: Adds a step_counter service token and a stock
+    implementation (1 of 3 related examples).
 python_name: step_counter
 repository: ''
 test: true

--- a/compat_4a/.gitignore
+++ b/compat_4a/.gitignore
@@ -1,0 +1,125 @@
+*.bundle.*
+lib/
+node_modules/
+*.log
+.eslintcache
+.stylelintcache
+*.egg-info/
+.ipynb_checkpoints
+*.tsbuildinfo
+step_counter/labextension
+# Version file is handled by hatchling
+step_counter/_version.py
+
+# Integration tests
+ui-tests/test-results/
+ui-tests/playwright-report/
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage/
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python
+
+# OSX files
+.DS_Store
+
+# Yarn cache
+.yarn/

--- a/compat_4a/.prettierignore
+++ b/compat_4a/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+**/node_modules
+**/lib
+**/package.json
+!/package.json
+step_counter

--- a/compat_4a/.yarnrc.yml
+++ b/compat_4a/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/compat_4a/README.md
+++ b/compat_4a/README.md
@@ -1,0 +1,96 @@
+# step_counter
+
+[![Github Actions Status](/workflows/Build/badge.svg)](/actions/workflows/build.yml)
+Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds a provider token.
+
+## Requirements
+
+- JupyterLab >= 4.0.0
+
+## Install
+
+To install the extension, execute:
+
+```bash
+pip install step_counter
+```
+
+## Uninstall
+
+To remove the extension, execute:
+
+```bash
+pip uninstall step_counter
+```
+
+## Contributing
+
+### Development install
+
+Note: You will need NodeJS to build the extension package.
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
+
+```bash
+# Clone the repo to your local environment
+# Change directory to the step_counter directory
+# Install package in development mode
+pip install -e "."
+# Link your development version of the extension with JupyterLab
+jupyter labextension develop . --overwrite
+# Rebuild extension Typescript source after making changes
+jlpm build
+```
+
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+
+```bash
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm watch
+# Run JupyterLab in another terminal
+jupyter lab
+```
+
+With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
+
+By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+
+```bash
+jupyter lab build --minimize=False
+```
+
+### Development uninstall
+
+```bash
+pip uninstall step_counter
+```
+
+In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
+command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
+folder is located. Then you can remove the symlink named `step_counter` within that folder.
+
+### Testing the extension
+
+#### Frontend tests
+
+This extension is using [Jest](https://jestjs.io/) for JavaScript code testing.
+
+To execute them, execute:
+
+```sh
+jlpm
+jlpm test
+```
+
+#### Integration tests
+
+This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
+More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
+
+More information are provided within the [ui-tests](./ui-tests/README.md) README.
+
+### Packaging the extension
+
+See [RELEASE](RELEASE.md)

--- a/compat_4a/babel.config.js
+++ b/compat_4a/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/compat_4a/install.json
+++ b/compat_4a/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "step_counter",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package step_counter"
+}

--- a/compat_4a/jest.config.js
+++ b/compat_4a/jest.config.js
@@ -1,0 +1,28 @@
+const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
+
+const esModules = [
+  '@codemirror',
+  '@jupyter/ydoc',
+  '@jupyterlab/',
+  'lib0',
+  'nanoid',
+  'vscode-ws-jsonrpc',
+  'y-protocols',
+  'y-websocket',
+  'yjs'
+].join('|');
+
+const baseConfig = jestJupyterLab(__dirname);
+
+module.exports = {
+  ...baseConfig,
+  automock: false,
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/.ipynb_checkpoints/*'
+  ],
+  coverageReporters: ['lcov', 'text'],
+  testRegex: 'src/.*/.*.spec.ts[x]?$',
+  transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`]
+};

--- a/compat_4a/package.json
+++ b/compat_4a/package.json
@@ -1,0 +1,201 @@
+{
+    "name": "step_counter",
+    "version": "0.1.0",
+    "description": "Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds a provider token.",
+    "keywords": [
+        "jupyter",
+        "jupyterlab",
+        "jupyterlab-extension"
+    ],
+    "homepage": "",
+    "bugs": {
+        "url": "/issues"
+    },
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "My Name",
+        "email": "me@test.com"
+    },
+    "files": [
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    ],
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "style": "style/index.css",
+    "repository": {
+        "type": "git",
+        "url": ".git"
+    },
+    "workspaces": [
+        "ui-tests"
+    ],
+    "scripts": {
+        "build": "jlpm build:lib && jlpm build:labextension:dev",
+        "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
+        "build:labextension": "jupyter labextension build .",
+        "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:lib": "tsc --sourceMap",
+        "build:lib:prod": "tsc",
+        "clean": "jlpm clean:lib",
+        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+        "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+        "clean:labextension": "rimraf step_counter/labextension step_counter/_version.py",
+        "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "install:extension": "jlpm build",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+        "test": "jest --coverage",
+        "watch": "run-p watch:src watch:labextension",
+        "watch:src": "tsc -w --sourceMap",
+        "watch:labextension": "jupyter labextension watch ."
+    },
+    "dependencies": {
+        "@lumino/coreutils": "^2.1.2"
+    },
+    "devDependencies": {
+        "@jupyterlab/builder": "^4.0.0",
+        "@jupyterlab/testutils": "^4.0.0",
+        "@types/jest": "^29.2.0",
+        "@types/json-schema": "^7.0.11",
+        "@types/react": "^18.0.26",
+        "@types/react-addons-linked-state-mixin": "^0.14.22",
+        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@typescript-eslint/parser": "^6.1.0",
+        "css-loader": "^6.7.1",
+        "eslint": "^8.36.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "jest": "^29.2.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^3.0.0",
+        "rimraf": "^5.0.1",
+        "source-map-loader": "^1.0.2",
+        "style-loader": "^3.3.1",
+        "stylelint": "^15.10.1",
+        "stylelint-config-recommended": "^13.0.0",
+        "stylelint-config-standard": "^34.0.0",
+        "stylelint-csstree-validator": "^3.0.0",
+        "stylelint-prettier": "^4.0.0",
+        "typescript": "~5.0.2",
+        "yjs": "^13.5.0"
+    },
+    "sideEffects": [
+        "style/*.css",
+        "style/index.js"
+    ],
+    "styleModule": "style/index.js",
+    "publishConfig": {
+        "access": "public"
+    },
+    "jupyterlab": {
+        "extension": true,
+        "outputDir": "step_counter/labextension",
+        "sharedPackages": {
+            "step_counter": {
+                "bundled": false,
+                "singleton": true
+            }
+        }
+    },
+    "eslintIgnore": [
+        "node_modules",
+        "dist",
+        "coverage",
+        "**/*.d.ts",
+        "tests",
+        "**/__tests__",
+        "ui-tests"
+    ],
+    "eslintConfig": {
+        "extends": [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended",
+            "plugin:prettier/recommended"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+            "project": "tsconfig.json",
+            "sourceType": "module"
+        },
+        "plugins": [
+            "@typescript-eslint"
+        ],
+        "rules": {
+            "@typescript-eslint/naming-convention": [
+                "error",
+                {
+                    "selector": "interface",
+                    "format": [
+                        "PascalCase"
+                    ],
+                    "custom": {
+                        "regex": "^I[A-Z]",
+                        "match": true
+                    }
+                }
+            ],
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    "args": "none"
+                }
+            ],
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-namespace": "off",
+            "@typescript-eslint/no-use-before-define": "off",
+            "@typescript-eslint/quotes": [
+                "error",
+                "single",
+                {
+                    "avoidEscape": true,
+                    "allowTemplateLiterals": false
+                }
+            ],
+            "curly": [
+                "error",
+                "all"
+            ],
+            "eqeqeq": "error",
+            "prefer-arrow-callback": "error"
+        }
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "avoid",
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
+    },
+    "stylelint": {
+        "extends": [
+            "stylelint-config-recommended",
+            "stylelint-config-standard",
+            "stylelint-prettier/recommended"
+        ],
+        "plugins": [
+            "stylelint-csstree-validator"
+        ],
+        "rules": {
+            "csstree/validator": true,
+            "property-no-vendor-prefix": null,
+            "selector-no-vendor-prefix": null,
+            "value-no-vendor-prefix": null
+        }
+    }
+}

--- a/compat_4a/package.json
+++ b/compat_4a/package.json
@@ -1,7 +1,7 @@
 {
     "name": "step_counter",
     "version": "0.1.0",
-    "description": "Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds a provider token.",
+    "description": "Adds a step_counter service token and a stock implementation (1 of 3 related examples).",
     "keywords": [
         "jupyter",
         "jupyterlab",

--- a/compat_4a/pyproject.toml
+++ b/compat_4a/pyproject.toml
@@ -1,0 +1,76 @@
+[build-system]
+requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version"]
+build-backend = "hatchling.build"
+
+[project]
+name = "step_counter"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.8"
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+]
+dynamic = ["version", "description", "authors", "urls", "keywords"]
+
+[tool.hatch.version]
+source = "nodejs"
+
+[tool.hatch.metadata.hooks.nodejs]
+fields = ["description", "authors", "urls"]
+
+[tool.hatch.build.targets.sdist]
+artifacts = ["step_counter/labextension"]
+exclude = [".github", "binder"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"step_counter/labextension" = "share/jupyter/labextensions/step_counter"
+"install.json" = "share/jupyter/labextensions/step_counter/install.json"
+
+[tool.hatch.build.hooks.version]
+path = "step_counter/_version.py"
+
+[tool.hatch.build.hooks.jupyter-builder]
+dependencies = ["hatch-jupyter-builder>=0.5"]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = [
+    "step_counter/labextension/static/style.js",
+    "step_counter/labextension/package.json",
+]
+skip-if-exists = ["step_counter/labextension/static/style.js"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+build_cmd = "build:prod"
+npm = ["jlpm"]
+
+[tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
+build_cmd = "install:extension"
+npm = ["jlpm"]
+source_dir = "src"
+build_dir = "step_counter/labextension"
+
+[tool.jupyter-releaser.options]
+version_cmd = "hatch version"
+
+[tool.jupyter-releaser.hooks]
+before-build-npm = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "jlpm",
+    "jlpm build:prod"
+]
+before-build-python = ["jlpm clean:all"]
+
+[tool.check-wheel-contents]
+ignore = ["W002"]

--- a/compat_4a/setup.py
+++ b/compat_4a/setup.py
@@ -1,0 +1,1 @@
+__import__("setuptools").setup()

--- a/compat_4a/src/__tests__/step_counter.spec.ts
+++ b/compat_4a/src/__tests__/step_counter.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
+ */
+
+describe('step_counter', () => {
+  it('should be tested', () => {
+    expect(1 + 1).toEqual(2);
+  });
+});

--- a/compat_4a/src/index.ts
+++ b/compat_4a/src/index.ts
@@ -1,3 +1,27 @@
+// This is one of three related extension examples that demonstrate
+// JupyterLab's provider-consumer pattern, where plugins can depend
+// on and reuse features from one another. The three packages that
+// make up the complete example are:
+//
+//   1. The step_counter package (this one). This holds a token, a
+//      class and interface that make up a stock implementation of
+//      the "step_counter" service, and a provider plugin that
+//      makes an instance of the Counter available to JupyterLab
+//      as a service object.
+//   2. The step_counter_extension package, that holds a UI/interface
+//      in JupyterLab for users to count their steps that connects
+//      with/consumes the step_counter service object via a consumer plugin.
+//   3. The leap_counter_extension package, that holds an alternate
+//      way for users to count leaps. Like the step_counter_extension
+//      package, this holds a UI/interface in JupyterLab, and a consumer
+//      plugin that also requests/consumes the step_counter service
+//      object. The leap_counter_extension package demonstrates how
+//      an unrelated plugin can depend on and reuse features from
+//      an existing plugin. Users can add install either the
+//      step_counter_extension, the leap_counter_extension or both
+//      to get whichever features they prefer (with both reusing
+//      the step_counter service object).
+
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -5,18 +29,34 @@ import {
 
 import { Token } from '@lumino/coreutils';
 
+// The StepCounterItem interface is used as part of JupyterLab's
+// provider-consumer pattern. This interface is supplied to the
+// token instance (the StepCounter token), and JupyterLab will
+// use it to type-check any service-object associated with the
+// token that a provider plugin supplies to check that it conforms
+// to the interface.
 interface StepCounterItem {
   // registerStatusItem(id: string, statusItem: IStatusBar.IItem): IDisposable;
   getStepCount(): number;
   incrementStepCount(count: number): void;
 }
 
-// TODO define an interface for type checking the associated service
+// The token is used to identify a particular "service" in
+// JupyterLab's extension system (here the StepCounter token
+// identifies the example "Step Counter Service", which is used
+// to store and increment step count data in JupyterLab). Any
+// plugin can use this token in their "requires" or "activates"
+// list to request the service object associated with this token!
 const StepCounter = new Token<StepCounterItem>(
   'step_counter:StepCounter',
   'A service for counting steps.'
 );
 
+// This class holds step count data/utilities. An instance of
+// this class will serve as the service object associated with
+// the StepCounter token (Other developers can substitute their
+// own implementation of a StepCounterItem instead of using this
+// one, by becoming a provider of the StepCounter token).
 class Counter implements StepCounterItem {
 
   _stepCount: number;
@@ -34,15 +74,27 @@ class Counter implements StepCounterItem {
   }
 }
 
+// This plugin is a "provider" in JupyterLab's provider-consumer pattern.
+// For a plugin to become a provider, it must list the token it wants to
+// provide a service object for in its "provides" list, and then it has
+// to return that object (in this case, an instance of the example Counter
+// class defined above) from the function supplied as its activate property.
+// It also needs to supply the interface (the one the service object
+// implements) to JupyterFrontEndPlugin when it's defined.
 const plugin: JupyterFrontEndPlugin<StepCounterItem> = {
   id: 'step_counter:provider_plugin',
   description: 'Provider plugin for the step_counter\'s "counter" service object.',
   autoStart: true,
   provides: StepCounter,
+  // The activate function here will be called by JupyterLab when the plugin loads
   activate: (app: JupyterFrontEnd) => {
     console.log('JupyterLab X1 extension step_counter\'s provider plugin is activated!');
     const counter = new Counter();
 
+    // Since this plugin "provides" the "StepCounter" service, make sure to
+    // return the object you want to use as the "service object" here (when
+    // other plugins request the StepCounter service, it is this object
+    // that will be supplied)
     return counter;
   }
 };

--- a/compat_4a/src/index.ts
+++ b/compat_4a/src/index.ts
@@ -12,7 +12,7 @@
 //      in JupyterLab for users to count their steps that connects
 //      with/consumes the step_counter service object via a consumer plugin.
 //   3. The leap_counter_extension package, that holds an alternate
-//      way for users to count leaps. Like the step_counter_extension
+//      way for users to count steps (a leap is 5 steps). Like the step_counter_extension
 //      package, this holds a UI/interface in JupyterLab, and a consumer
 //      plugin that also requests/consumes the step_counter service
 //      object. The leap_counter_extension package demonstrates how

--- a/compat_4a/src/index.ts
+++ b/compat_4a/src/index.ts
@@ -88,7 +88,7 @@ const plugin: JupyterFrontEndPlugin<StepCounterItem> = {
   provides: StepCounter,
   // The activate function here will be called by JupyterLab when the plugin loads
   activate: (app: JupyterFrontEnd) => {
-    console.log('JupyterLab X1 extension step_counter\'s provider plugin is activated!');
+    console.log('JupyterLab extension (step_counter/provider plugin) is activated!');
     const counter = new Counter();
 
     // Since this plugin "provides" the "StepCounter" service, make sure to

--- a/compat_4a/src/index.ts
+++ b/compat_4a/src/index.ts
@@ -1,0 +1,51 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { Token } from '@lumino/coreutils';
+
+interface StepCounterItem {
+  // registerStatusItem(id: string, statusItem: IStatusBar.IItem): IDisposable;
+  getStepCount(): number;
+  incrementStepCount(count: number): void;
+}
+
+// TODO define an interface for type checking the associated service
+const StepCounter = new Token<StepCounterItem>(
+  'step_counter:StepCounter',
+  'A service for counting steps.'
+);
+
+class Counter implements StepCounterItem {
+
+  _stepCount: number;
+
+  constructor() {
+    this._stepCount = 0;
+  }
+
+  incrementStepCount(count: number) {
+    this._stepCount += count;
+  }
+
+  getStepCount() {
+    return this._stepCount;
+  }
+}
+
+const plugin: JupyterFrontEndPlugin<StepCounterItem> = {
+  id: 'step_counter:provider_plugin',
+  description: 'Provider plugin for the step_counter\'s "counter" service object.',
+  autoStart: true,
+  provides: StepCounter,
+  activate: (app: JupyterFrontEnd) => {
+    console.log('JupyterLab X1 extension step_counter\'s provider plugin is activated!');
+    const counter = new Counter();
+
+    return counter;
+  }
+};
+
+export { StepCounter, StepCounterItem };
+export default plugin;

--- a/compat_4a/src/index.ts
+++ b/compat_4a/src/index.ts
@@ -4,7 +4,7 @@
 // make up the complete example are:
 //
 //   1. (*) The step_counter package (this one). This holds a token, a
-//      class and interface that make up a stock implementation of
+//      class + an interface that make up a stock implementation of
 //      the "step_counter" service, and a provider plugin that
 //      makes an instance of the Counter available to JupyterLab
 //      as a service object.

--- a/compat_4a/src/index.ts
+++ b/compat_4a/src/index.ts
@@ -3,7 +3,7 @@
 // on and reuse features from one another. The three packages that
 // make up the complete example are:
 //
-//   1. The step_counter package (this one). This holds a token, a
+//   1. (*) The step_counter package (this one). This holds a token, a
 //      class and interface that make up a stock implementation of
 //      the "step_counter" service, and a provider plugin that
 //      makes an instance of the Counter available to JupyterLab

--- a/compat_4a/src/index.ts
+++ b/compat_4a/src/index.ts
@@ -17,7 +17,7 @@
 //      plugin that also requests/consumes the step_counter service
 //      object. The leap_counter_extension package demonstrates how
 //      an unrelated plugin can depend on and reuse features from
-//      an existing plugin. Users can add install either the
+//      an existing plugin. Users can install either the
 //      step_counter_extension, the leap_counter_extension or both
 //      to get whichever features they prefer (with both reusing
 //      the step_counter service object).

--- a/compat_4a/step_counter/__init__.py
+++ b/compat_4a/step_counter/__init__.py
@@ -1,0 +1,16 @@
+try:
+    from ._version import __version__
+except ImportError:
+    # Fallback when using the package in dev mode without installing
+    # in editable mode with pip. It is highly recommended to install
+    # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
+    import warnings
+    warnings.warn("Importing 'step_counter' outside a proper installation.")
+    __version__ = "dev"
+
+
+def _jupyter_labextension_paths():
+    return [{
+        "src": "labextension",
+        "dest": "step_counter"
+    }]

--- a/compat_4a/style/base.css
+++ b/compat_4a/style/base.css
@@ -1,0 +1,5 @@
+/*
+    See the JupyterLab Developer Guide for useful CSS Patterns:
+
+    https://jupyterlab.readthedocs.io/en/stable/developer/css.html
+*/

--- a/compat_4a/style/index.css
+++ b/compat_4a/style/index.css
@@ -1,0 +1,1 @@
+@import url('base.css');

--- a/compat_4a/style/index.js
+++ b/compat_4a/style/index.js
@@ -1,0 +1,1 @@
+import './base.css';

--- a/compat_4a/tsconfig.json
+++ b/compat_4a/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "ES2018"
+  },
+  "include": ["src/*"]
+}

--- a/compat_4a/tsconfig.test.json
+++ b/compat_4a/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "types": ["jest"]
+  }
+}

--- a/compat_4a/ui-tests/README.md
+++ b/compat_4a/ui-tests/README.md
@@ -1,0 +1,167 @@
+# Integration Testing
+
+This folder contains the integration tests of the extension.
+
+They are defined using [Playwright](https://playwright.dev/docs/intro) test runner
+and [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) helper.
+
+The Playwright configuration is defined in [playwright.config.js](./playwright.config.js).
+
+The JupyterLab server configuration to use for the integration test is defined
+in [jupyter_server_test_config.py](./jupyter_server_test_config.py).
+
+The default configuration will produce video for failing tests and an HTML report.
+
+> There is a new experimental UI mode that you may fall in love with; see [that video](https://www.youtube.com/watch?v=jF0yA-JLQW0).
+
+## Run the tests
+
+> All commands are assumed to be executed from the root directory
+
+To run the tests, you need to:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the [Playwright](https://playwright.dev/docs/intro) tests:
+
+```sh
+cd ./ui-tests
+jlpm playwright test
+```
+
+Test results will be shown in the terminal. In case of any test failures, the test report
+will be opened in your browser at the end of the tests execution; see
+[Playwright documentation](https://playwright.dev/docs/test-reporters#html-reporter)
+for configuring that behavior.
+
+## Update the tests snapshots
+
+> All commands are assumed to be executed from the root directory
+
+If you are comparing snapshots to validate your tests, you may need to update
+the reference snapshots stored in the repository. To do that, you need to:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the [Playwright](https://playwright.dev/docs/intro) command:
+
+```sh
+cd ./ui-tests
+jlpm playwright test -u
+```
+
+> Some discrepancy may occurs between the snapshots generated on your computer and
+> the one generated on the CI. To ease updating the snapshots on a PR, you can
+> type `please update playwright snapshots` to trigger the update by a bot on the CI.
+> Once the bot has computed new snapshots, it will commit them to the PR branch.
+
+## Create tests
+
+> All commands are assumed to be executed from the root directory
+
+To create tests, the easiest way is to use the code generator tool of playwright:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Start the server:
+
+```sh
+cd ./ui-tests
+jlpm start
+```
+
+4. Execute the [Playwright code generator](https://playwright.dev/docs/codegen) in **another terminal**:
+
+```sh
+cd ./ui-tests
+jlpm playwright codegen localhost:8888
+```
+
+## Debug tests
+
+> All commands are assumed to be executed from the root directory
+
+To debug tests, a good way is to use the inspector tool of playwright:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the Playwright tests in [debug mode](https://playwright.dev/docs/debug):
+
+```sh
+cd ./ui-tests
+jlpm playwright test --debug
+```
+
+## Upgrade Playwright and the browsers
+
+To update the web browser versions, you must update the package `@playwright/test`:
+
+```sh
+cd ./ui-tests
+jlpm up "@playwright/test"
+jlpm playwright install
+```

--- a/compat_4a/ui-tests/jupyter_server_test_config.py
+++ b/compat_4a/ui-tests/jupyter_server_test_config.py
@@ -1,0 +1,12 @@
+"""Server configuration for integration tests.
+
+!! Never use this configuration in production because it
+opens the server to the world and provide access to JupyterLab
+JavaScript objects through the global window variable.
+"""
+from jupyterlab.galata import configure_jupyter_server
+
+configure_jupyter_server(c)
+
+# Uncomment to set server log level to debug level
+# c.ServerApp.log_level = "DEBUG"

--- a/compat_4a/ui-tests/package.json
+++ b/compat_4a/ui-tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "step_counter-ui-tests",
+  "version": "1.0.0",
+  "description": "JupyterLab step_counter Integration Tests",
+  "private": true,
+  "scripts": {
+    "start": "jupyter lab --config jupyter_server_test_config.py",
+    "test": "jlpm playwright test",
+    "test:update": "jlpm playwright test --update-snapshots"
+  },
+  "devDependencies": {
+    "@jupyterlab/galata": "^5.0.5",
+    "@playwright/test": "^1.37.0"
+  }
+}

--- a/compat_4a/ui-tests/playwright.config.js
+++ b/compat_4a/ui-tests/playwright.config.js
@@ -1,0 +1,14 @@
+/**
+ * Configuration for Playwright using default from @jupyterlab/galata
+ */
+const baseConfig = require('@jupyterlab/galata/lib/playwright-config');
+
+module.exports = {
+  ...baseConfig,
+  webServer: {
+    command: 'jlpm start',
+    url: 'http://localhost:8888/lab',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI
+  }
+};

--- a/compat_4a/ui-tests/tests/step_counter.spec.ts
+++ b/compat_4a/ui-tests/tests/step_counter.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jupyterlab/galata';
+
+/**
+ * Don't load JupyterLab webpage before running the tests.
+ * This is required to ensure we capture all log messages.
+ */
+test.use({ autoGoto: false });
+
+test('should emit an activation console message', async ({ page }) => {
+  const logs: string[] = [];
+
+  page.on('console', message => {
+    logs.push(message.text());
+  });
+
+  await page.goto();
+
+  expect(
+    logs.filter(s => s === 'JupyterLab extension step_counter is activated!')
+  ).toHaveLength(1);
+});

--- a/compat_4b/.copier-answers.yml
+++ b/compat_4b/.copier-answers.yml
@@ -7,8 +7,8 @@ has_binder: false
 has_settings: false
 kind: frontend
 labextension_name: step_counter_extension
-project_short_description: Adds a step counter/button, and a step increment provider
-    (1 of 3 related examples). This extension holds the UI/plugin implementation.
+project_short_description: Adds a step counter/button (1 of 3 related examples).
+    This extension holds the UI/interface.
 python_name: step_counter_extension
 repository: ''
 test: true

--- a/compat_4b/.copier-answers.yml
+++ b/compat_4b/.copier-answers.yml
@@ -1,0 +1,15 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+_commit: v4.2.0
+_src_path: https://github.com/jupyterlab/extension-template
+author_email: me@test.com
+author_name: My Name
+has_binder: false
+has_settings: false
+kind: frontend
+labextension_name: step_counter_extension
+project_short_description: Adds a step counter/button, and a step increment provider
+    (1 of 3 related examples). This extension holds the UI/plugin implementation.
+python_name: step_counter_extension
+repository: ''
+test: true
+

--- a/compat_4b/.gitignore
+++ b/compat_4b/.gitignore
@@ -1,0 +1,125 @@
+*.bundle.*
+lib/
+node_modules/
+*.log
+.eslintcache
+.stylelintcache
+*.egg-info/
+.ipynb_checkpoints
+*.tsbuildinfo
+step_counter_extension/labextension
+# Version file is handled by hatchling
+step_counter_extension/_version.py
+
+# Integration tests
+ui-tests/test-results/
+ui-tests/playwright-report/
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage/
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python
+
+# OSX files
+.DS_Store
+
+# Yarn cache
+.yarn/

--- a/compat_4b/.prettierignore
+++ b/compat_4b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+**/node_modules
+**/lib
+**/package.json
+!/package.json
+step_counter_extension

--- a/compat_4b/.yarnrc.yml
+++ b/compat_4b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/compat_4b/README.md
+++ b/compat_4b/README.md
@@ -1,0 +1,96 @@
+# step_counter_extension
+
+[![Github Actions Status](/workflows/Build/badge.svg)](/actions/workflows/build.yml)
+Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds the UI/plugin implementation.
+
+## Requirements
+
+- JupyterLab >= 4.0.0
+
+## Install
+
+To install the extension, execute:
+
+```bash
+pip install step_counter_extension
+```
+
+## Uninstall
+
+To remove the extension, execute:
+
+```bash
+pip uninstall step_counter_extension
+```
+
+## Contributing
+
+### Development install
+
+Note: You will need NodeJS to build the extension package.
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
+
+```bash
+# Clone the repo to your local environment
+# Change directory to the step_counter_extension directory
+# Install package in development mode
+pip install -e "."
+# Link your development version of the extension with JupyterLab
+jupyter labextension develop . --overwrite
+# Rebuild extension Typescript source after making changes
+jlpm build
+```
+
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+
+```bash
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm watch
+# Run JupyterLab in another terminal
+jupyter lab
+```
+
+With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
+
+By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+
+```bash
+jupyter lab build --minimize=False
+```
+
+### Development uninstall
+
+```bash
+pip uninstall step_counter_extension
+```
+
+In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
+command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
+folder is located. Then you can remove the symlink named `step_counter_extension` within that folder.
+
+### Testing the extension
+
+#### Frontend tests
+
+This extension is using [Jest](https://jestjs.io/) for JavaScript code testing.
+
+To execute them, execute:
+
+```sh
+jlpm
+jlpm test
+```
+
+#### Integration tests
+
+This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
+More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
+
+More information are provided within the [ui-tests](./ui-tests/README.md) README.
+
+### Packaging the extension
+
+See [RELEASE](RELEASE.md)

--- a/compat_4b/babel.config.js
+++ b/compat_4b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/compat_4b/install.json
+++ b/compat_4b/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "step_counter_extension",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package step_counter_extension"
+}

--- a/compat_4b/jest.config.js
+++ b/compat_4b/jest.config.js
@@ -1,0 +1,28 @@
+const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
+
+const esModules = [
+  '@codemirror',
+  '@jupyter/ydoc',
+  '@jupyterlab/',
+  'lib0',
+  'nanoid',
+  'vscode-ws-jsonrpc',
+  'y-protocols',
+  'y-websocket',
+  'yjs'
+].join('|');
+
+const baseConfig = jestJupyterLab(__dirname);
+
+module.exports = {
+  ...baseConfig,
+  automock: false,
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/.ipynb_checkpoints/*'
+  ],
+  coverageReporters: ['lcov', 'text'],
+  testRegex: 'src/.*/.*.spec.ts[x]?$',
+  transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`]
+};

--- a/compat_4b/package.json
+++ b/compat_4b/package.json
@@ -1,0 +1,203 @@
+{
+    "name": "step_counter_extension",
+    "version": "0.1.0",
+    "description": "Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds the UI/plugin implementation.",
+    "keywords": [
+        "jupyter",
+        "jupyterlab",
+        "jupyterlab-extension"
+    ],
+    "homepage": "",
+    "bugs": {
+        "url": "/issues"
+    },
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "My Name",
+        "email": "me@test.com"
+    },
+    "files": [
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    ],
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "style": "style/index.css",
+    "repository": {
+        "type": "git",
+        "url": ".git"
+    },
+    "workspaces": [
+        "ui-tests"
+    ],
+    "scripts": {
+        "build": "jlpm build:lib && jlpm build:labextension:dev",
+        "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
+        "build:labextension": "jupyter labextension build .",
+        "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:lib": "tsc --sourceMap",
+        "build:lib:prod": "tsc",
+        "clean": "jlpm clean:lib",
+        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+        "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+        "clean:labextension": "rimraf step_counter_extension/labextension step_counter_extension/_version.py",
+        "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "install:extension": "jlpm build",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+        "test": "jest --coverage",
+        "watch": "run-p watch:src watch:labextension",
+        "watch:src": "tsc -w --sourceMap",
+        "watch:labextension": "jupyter labextension watch ."
+    },
+    "dependencies": {
+        "@jupyterlab/application": "^4.0.0",
+        "@lumino/widgets": "^2.0.0",
+        "step_counter": "file:./../compat_4a"
+    },
+    "devDependencies": {
+        "@jupyterlab/builder": "^4.0.0",
+        "@jupyterlab/testutils": "^4.0.0",
+        "@types/jest": "^29.2.0",
+        "@types/json-schema": "^7.0.11",
+        "@types/react": "^18.0.26",
+        "@types/react-addons-linked-state-mixin": "^0.14.22",
+        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@typescript-eslint/parser": "^6.1.0",
+        "css-loader": "^6.7.1",
+        "eslint": "^8.36.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "jest": "^29.2.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^3.0.0",
+        "rimraf": "^5.0.1",
+        "source-map-loader": "^1.0.2",
+        "style-loader": "^3.3.1",
+        "stylelint": "^15.10.1",
+        "stylelint-config-recommended": "^13.0.0",
+        "stylelint-config-standard": "^34.0.0",
+        "stylelint-csstree-validator": "^3.0.0",
+        "stylelint-prettier": "^4.0.0",
+        "typescript": "~5.0.2",
+        "yjs": "^13.5.0"
+    },
+    "sideEffects": [
+        "style/*.css",
+        "style/index.js"
+    ],
+    "styleModule": "style/index.js",
+    "publishConfig": {
+        "access": "public"
+    },
+    "jupyterlab": {
+        "extension": true,
+        "outputDir": "step_counter_extension/labextension",
+        "sharedPackages": {
+            "step_counter": {
+                "bundled": false,
+                "singleton": true
+            }
+        }
+    },
+    "eslintIgnore": [
+        "node_modules",
+        "dist",
+        "coverage",
+        "**/*.d.ts",
+        "tests",
+        "**/__tests__",
+        "ui-tests"
+    ],
+    "eslintConfig": {
+        "extends": [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended",
+            "plugin:prettier/recommended"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+            "project": "tsconfig.json",
+            "sourceType": "module"
+        },
+        "plugins": [
+            "@typescript-eslint"
+        ],
+        "rules": {
+            "@typescript-eslint/naming-convention": [
+                "error",
+                {
+                    "selector": "interface",
+                    "format": [
+                        "PascalCase"
+                    ],
+                    "custom": {
+                        "regex": "^I[A-Z]",
+                        "match": true
+                    }
+                }
+            ],
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    "args": "none"
+                }
+            ],
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-namespace": "off",
+            "@typescript-eslint/no-use-before-define": "off",
+            "@typescript-eslint/quotes": [
+                "error",
+                "single",
+                {
+                    "avoidEscape": true,
+                    "allowTemplateLiterals": false
+                }
+            ],
+            "curly": [
+                "error",
+                "all"
+            ],
+            "eqeqeq": "error",
+            "prefer-arrow-callback": "error"
+        }
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "avoid",
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
+    },
+    "stylelint": {
+        "extends": [
+            "stylelint-config-recommended",
+            "stylelint-config-standard",
+            "stylelint-prettier/recommended"
+        ],
+        "plugins": [
+            "stylelint-csstree-validator"
+        ],
+        "rules": {
+            "csstree/validator": true,
+            "property-no-vendor-prefix": null,
+            "selector-no-vendor-prefix": null,
+            "value-no-vendor-prefix": null
+        }
+    }
+}

--- a/compat_4b/package.json
+++ b/compat_4b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "step_counter_extension",
     "version": "0.1.0",
-    "description": "Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds the UI/plugin implementation.",
+    "description": "Adds a step counter/button (1 of 3 related examples). This extension holds the UI/interface.",
     "keywords": [
         "jupyter",
         "jupyterlab",

--- a/compat_4b/pyproject.toml
+++ b/compat_4b/pyproject.toml
@@ -1,0 +1,76 @@
+[build-system]
+requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version"]
+build-backend = "hatchling.build"
+
+[project]
+name = "step_counter_extension"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.8"
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+]
+dynamic = ["version", "description", "authors", "urls", "keywords"]
+
+[tool.hatch.version]
+source = "nodejs"
+
+[tool.hatch.metadata.hooks.nodejs]
+fields = ["description", "authors", "urls"]
+
+[tool.hatch.build.targets.sdist]
+artifacts = ["step_counter_extension/labextension"]
+exclude = [".github", "binder"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"step_counter_extension/labextension" = "share/jupyter/labextensions/step_counter_extension"
+"install.json" = "share/jupyter/labextensions/step_counter_extension/install.json"
+
+[tool.hatch.build.hooks.version]
+path = "step_counter_extension/_version.py"
+
+[tool.hatch.build.hooks.jupyter-builder]
+dependencies = ["hatch-jupyter-builder>=0.5"]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = [
+    "step_counter_extension/labextension/static/style.js",
+    "step_counter_extension/labextension/package.json",
+]
+skip-if-exists = ["step_counter_extension/labextension/static/style.js"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+build_cmd = "build:prod"
+npm = ["jlpm"]
+
+[tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
+build_cmd = "install:extension"
+npm = ["jlpm"]
+source_dir = "src"
+build_dir = "step_counter_extension/labextension"
+
+[tool.jupyter-releaser.options]
+version_cmd = "hatch version"
+
+[tool.jupyter-releaser.hooks]
+before-build-npm = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "jlpm",
+    "jlpm build:prod"
+]
+before-build-python = ["jlpm clean:all"]
+
+[tool.check-wheel-contents]
+ignore = ["W002"]

--- a/compat_4b/setup.py
+++ b/compat_4b/setup.py
@@ -1,0 +1,1 @@
+__import__("setuptools").setup()

--- a/compat_4b/src/__tests__/step_counter_extension.spec.ts
+++ b/compat_4b/src/__tests__/step_counter_extension.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
+ */
+
+describe('step_counter_extension', () => {
+  it('should be tested', () => {
+    expect(1 + 1).toEqual(2);
+  });
+});

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -1,3 +1,28 @@
+// This is one of three related extension examples that demonstrate
+// JupyterLab's provider-consumer pattern, where plugins can depend
+// on and reuse features from one another. The three packages that
+// make up the complete example are:
+//
+//   1. The step_counter package. This package holds a token, a
+//      class and interface that make up a stock implementation of
+//      the "step_counter" service, and a provider plugin that
+//      makes an instance of the Counter available to JupyterLab
+//      as a service object.
+//   2. (*) The step_counter_extension package (this one), that holds a
+//      UI/interface in JupyterLab for users to count their steps that
+//      connects with/consumes the step_counter service object via a
+//      consumer plugin.
+//   3. The leap_counter_extension package, that holds an alternate
+//      way for users to count leaps. Like the step_counter_extension
+//      package, this holds a UI/interface in JupyterLab, and a consumer
+//      plugin that also requests/consumes the step_counter service
+//      object. The leap_counter_extension package demonstrates how
+//      an unrelated plugin can depend on and reuse features from
+//      an existing plugin. Users can add install either the
+//      step_counter_extension, the leap_counter_extension or both
+//      to get whichever features they prefer (with both reusing
+//      the step_counter service object).
+
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -7,31 +32,35 @@ import { Widget } from '@lumino/widgets';
 
 import { StepCounter} from "step_counter";
 
-/**
- * StepCounterWidget holds X
- */
+// This widget holds the JupyterLab UI/interface that users will
+// see and interact with to count and view their steps.
 class StepCounterWidget extends Widget {
 
   stepButton: HTMLElement;
   stepCountLabel: HTMLElement;
   counter: any;
 
+  // Notice that the constructor for this object takes a "counter"
+  // argument, which is the service object associated with the StepCounter
+  // token (which is passed in by the consumer plugin).
   constructor(counter: any) {
     super();
 
     this.counter = counter;
 
+    // Add styling by using a CSS class
     this.node.classList.add('jp-step-container');
 
     // Create and add a button to this widget's root node
     const stepButton = document.createElement('div');
     stepButton.innerText = 'Take a Step';
-    // Add a listener to TODO
+    // Add a listener to handle button clicks
     stepButton.addEventListener('click', this.takeStep.bind(this));
     stepButton.classList.add('jp-step-button');
     this.node.appendChild(stepButton);
     this.stepButton = stepButton;
 
+    // Add a label to display the step count
     const stepCountLabel = document.createElement('p');
     stepCountLabel.classList.add('jp-step-label');
     this.node.appendChild(stepCountLabel);
@@ -40,24 +69,43 @@ class StepCounterWidget extends Widget {
     this.updateStepCountDisplay();
   }
 
+  // Refresh the displayed step count
   updateStepCountDisplay() {
     this.stepCountLabel.innerText = 'Step Count: ' + this.counter.getStepCount();
   }
 
+  // Increment the step count, by just 1
   takeStep() {
     this.counter.incrementStepCount(1);
     this.updateStepCountDisplay();
   }
 }
 
-/**
- * Initialization data for the step_counter_extension extension.
- */
+// This plugin is a "provider" in JupyterLab's provider-consumer pattern.
+// For a plugin to become a provider, it must list the token it wants to
+// provide a service object for in its "provides" list, and then it has
+// to return that object (in this case, an instance of the example Counter
+// class defined above) from the function supplied as its activate property.
+// It also needs to supply the interface (the one the service object
+// implements) to JupyterFrontEndPlugin when it's defined.
+
+// This plugin is a "consumer" in JupyterLab's provider-consumer pattern.
+// The "requires" property of this plugin lists the StepCounter token, which
+// requests the service-object associated with that token from JupyterLab,
+// and this plugin "consumes" the service object by using it in its own code.
+// Whenever you add a "requires" or "optional" service, you need to manually
+// add an argument to your plugin's "activate" function.
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'step_counter_extension:plugin',
   description: 'Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds the UI/plugin implementation.',
   autoStart: true,
   requires: [StepCounter],
+  // The activate function here will be called by JupyterLab when the plugin loads.
+  // When JupyterLab calls your plugin's activate function, it will always pass
+  // an application as the first argument, then any required arguments, then any optional
+  // arguments, so make sure you add arguments for those here when your plugin requests
+  // any required or optional services. If a required service is missing, your plugin
+  // won't load. If an optional service is missing, the supplied argument will be null.
   activate: (app: JupyterFrontEnd, counter: any) => {
     console.log('JupyterLab extension step_counter_extension is activated!');
 

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -81,14 +81,6 @@ class StepCounterWidget extends Widget {
   }
 }
 
-// This plugin is a "provider" in JupyterLab's provider-consumer pattern.
-// For a plugin to become a provider, it must list the token it wants to
-// provide a service object for in its "provides" list, and then it has
-// to return that object (in this case, an instance of the example Counter
-// class defined above) from the function supplied as its activate property.
-// It also needs to supply the interface (the one the service object
-// implements) to JupyterFrontEndPlugin when it's defined.
-
 // This plugin is a "consumer" in JupyterLab's provider-consumer pattern.
 // The "requires" property of this plugin lists the StepCounter token, which
 // requests the service-object associated with that token from JupyterLab,

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -1,0 +1,71 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { Widget } from '@lumino/widgets';
+
+import { StepCounter} from "step_counter";
+
+/**
+ * StepCounterWidget holds X
+ */
+class StepCounterWidget extends Widget {
+
+  stepButton: HTMLElement;
+  stepCountLabel: HTMLElement;
+  counter: any;
+
+  constructor(counter: any) {
+    super();
+
+    this.counter = counter;
+
+    this.node.classList.add('jp-step-container');
+
+    // Create and add a button to this widget's root node
+    const stepButton = document.createElement('div');
+    stepButton.innerText = 'Take a Step';
+    // Add a listener to TODO
+    stepButton.addEventListener('click', this.takeStep.bind(this));
+    stepButton.classList.add('jp-step-button');
+    this.node.appendChild(stepButton);
+    this.stepButton = stepButton;
+
+    const stepCountLabel = document.createElement('p');
+    stepCountLabel.classList.add('jp-step-label');
+    this.node.appendChild(stepCountLabel);
+    this.stepCountLabel = stepCountLabel;
+
+    this.updateStepCountDisplay();
+  }
+
+  updateStepCountDisplay() {
+    this.stepCountLabel.innerText = 'Step Count: ' + this.counter.stepCount;
+  }
+
+  takeStep() {
+    this.counter.incrementStepCount(1);
+    this.updateStepCountDisplay();
+  }
+}
+
+/**
+ * Initialization data for the step_counter_extension extension.
+ */
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'step_counter_extension:plugin',
+  description: 'Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds the UI/plugin implementation.',
+  autoStart: true,
+  requires: [StepCounter],
+  activate: (app: JupyterFrontEnd, counter: any) => {
+    console.log('JupyterLab extension step_counter_extension is activated!');
+
+    // Create a StepCounterWidget and add it to the interface
+    const stepWidget: StepCounterWidget = new StepCounterWidget(counter);
+    stepWidget.id = 'JupyterStepWidget';  // Widgets need an id
+    app.shell.add(stepWidget, 'top');
+  }
+};
+
+export default plugin;

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -41,7 +41,7 @@ class StepCounterWidget extends Widget {
   }
 
   updateStepCountDisplay() {
-    this.stepCountLabel.innerText = 'Step Count: ' + this.counter.stepCount;
+    this.stepCountLabel.innerText = 'Step Count: ' + this.counter.getStepCount();
   }
 
   takeStep() {

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -18,7 +18,7 @@
 //      plugin that also requests/consumes the step_counter service
 //      object. The leap_counter_extension package demonstrates how
 //      an unrelated plugin can depend on and reuse features from
-//      an existing plugin. Users can add install either the
+//      an existing plugin. Users can install either the
 //      step_counter_extension, the leap_counter_extension or both
 //      to get whichever features they prefer (with both reusing
 //      the step_counter service object).

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -13,7 +13,7 @@
 //      connects with/consumes the step_counter service object via a
 //      consumer plugin.
 //   3. The leap_counter_extension package, that holds an alternate
-//      way for users to count leaps. Like the step_counter_extension
+//      way for users to count steps (a leap is 5 steps). Like the step_counter_extension
 //      package, this holds a UI/interface in JupyterLab, and a consumer
 //      plugin that also requests/consumes the step_counter service
 //      object. The leap_counter_extension package demonstrates how

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -89,7 +89,7 @@ class StepCounterWidget extends Widget {
 // add an argument to your plugin's "activate" function.
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'step_counter_extension:plugin',
-  description: 'Adds a step counter/button, and a step increment provider (1 of 3 related examples). This extension holds the UI/plugin implementation.',
+  description: 'Adds a step counter/button (1 of 3 related examples). This extension holds the UI/interface',
   autoStart: true,
   requires: [StepCounter],
   // The activate function here will be called by JupyterLab when the plugin loads.

--- a/compat_4b/src/index.ts
+++ b/compat_4b/src/index.ts
@@ -4,7 +4,7 @@
 // make up the complete example are:
 //
 //   1. The step_counter package. This package holds a token, a
-//      class and interface that make up a stock implementation of
+//      class + an interface that make up a stock implementation of
 //      the "step_counter" service, and a provider plugin that
 //      makes an instance of the Counter available to JupyterLab
 //      as a service object.

--- a/compat_4b/step_counter_extension/__init__.py
+++ b/compat_4b/step_counter_extension/__init__.py
@@ -1,0 +1,16 @@
+try:
+    from ._version import __version__
+except ImportError:
+    # Fallback when using the package in dev mode without installing
+    # in editable mode with pip. It is highly recommended to install
+    # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
+    import warnings
+    warnings.warn("Importing 'step_counter_extension' outside a proper installation.")
+    __version__ = "dev"
+
+
+def _jupyter_labextension_paths():
+    return [{
+        "src": "labextension",
+        "dest": "step_counter_extension"
+    }]

--- a/compat_4b/style/base.css
+++ b/compat_4b/style/base.css
@@ -1,0 +1,28 @@
+/*
+    See the JupyterLab Developer Guide for useful CSS Patterns:
+
+    https://jupyterlab.readthedocs.io/en/stable/developer/css.html
+*/
+
+.jp-step-container {
+    display: inline;
+    user-select: none;
+}
+
+.jp-step-button {
+    width: 85px;
+    margin: 4px;
+    padding: 2px;
+    text-align: center;
+    vertical-align: middle;
+    border-radius: 2px;
+    background-color: #2296f3;
+    color: #212121;
+    display: inline-block;
+}
+
+.jp-step-label {
+    display: inline-block;
+    margin: 6px;
+    vertical-align: middle;
+}

--- a/compat_4b/style/index.css
+++ b/compat_4b/style/index.css
@@ -1,0 +1,1 @@
+@import url('base.css');

--- a/compat_4b/style/index.js
+++ b/compat_4b/style/index.js
@@ -1,0 +1,1 @@
+import './base.css';

--- a/compat_4b/tsconfig.json
+++ b/compat_4b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "ES2018"
+  },
+  "include": ["src/*"]
+}

--- a/compat_4b/tsconfig.test.json
+++ b/compat_4b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "types": ["jest"]
+  }
+}

--- a/compat_4b/ui-tests/README.md
+++ b/compat_4b/ui-tests/README.md
@@ -1,0 +1,167 @@
+# Integration Testing
+
+This folder contains the integration tests of the extension.
+
+They are defined using [Playwright](https://playwright.dev/docs/intro) test runner
+and [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) helper.
+
+The Playwright configuration is defined in [playwright.config.js](./playwright.config.js).
+
+The JupyterLab server configuration to use for the integration test is defined
+in [jupyter_server_test_config.py](./jupyter_server_test_config.py).
+
+The default configuration will produce video for failing tests and an HTML report.
+
+> There is a new experimental UI mode that you may fall in love with; see [that video](https://www.youtube.com/watch?v=jF0yA-JLQW0).
+
+## Run the tests
+
+> All commands are assumed to be executed from the root directory
+
+To run the tests, you need to:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the [Playwright](https://playwright.dev/docs/intro) tests:
+
+```sh
+cd ./ui-tests
+jlpm playwright test
+```
+
+Test results will be shown in the terminal. In case of any test failures, the test report
+will be opened in your browser at the end of the tests execution; see
+[Playwright documentation](https://playwright.dev/docs/test-reporters#html-reporter)
+for configuring that behavior.
+
+## Update the tests snapshots
+
+> All commands are assumed to be executed from the root directory
+
+If you are comparing snapshots to validate your tests, you may need to update
+the reference snapshots stored in the repository. To do that, you need to:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the [Playwright](https://playwright.dev/docs/intro) command:
+
+```sh
+cd ./ui-tests
+jlpm playwright test -u
+```
+
+> Some discrepancy may occurs between the snapshots generated on your computer and
+> the one generated on the CI. To ease updating the snapshots on a PR, you can
+> type `please update playwright snapshots` to trigger the update by a bot on the CI.
+> Once the bot has computed new snapshots, it will commit them to the PR branch.
+
+## Create tests
+
+> All commands are assumed to be executed from the root directory
+
+To create tests, the easiest way is to use the code generator tool of playwright:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Start the server:
+
+```sh
+cd ./ui-tests
+jlpm start
+```
+
+4. Execute the [Playwright code generator](https://playwright.dev/docs/codegen) in **another terminal**:
+
+```sh
+cd ./ui-tests
+jlpm playwright codegen localhost:8888
+```
+
+## Debug tests
+
+> All commands are assumed to be executed from the root directory
+
+To debug tests, a good way is to use the inspector tool of playwright:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the Playwright tests in [debug mode](https://playwright.dev/docs/debug):
+
+```sh
+cd ./ui-tests
+jlpm playwright test --debug
+```
+
+## Upgrade Playwright and the browsers
+
+To update the web browser versions, you must update the package `@playwright/test`:
+
+```sh
+cd ./ui-tests
+jlpm up "@playwright/test"
+jlpm playwright install
+```

--- a/compat_4b/ui-tests/jupyter_server_test_config.py
+++ b/compat_4b/ui-tests/jupyter_server_test_config.py
@@ -1,0 +1,12 @@
+"""Server configuration for integration tests.
+
+!! Never use this configuration in production because it
+opens the server to the world and provide access to JupyterLab
+JavaScript objects through the global window variable.
+"""
+from jupyterlab.galata import configure_jupyter_server
+
+configure_jupyter_server(c)
+
+# Uncomment to set server log level to debug level
+# c.ServerApp.log_level = "DEBUG"

--- a/compat_4b/ui-tests/package.json
+++ b/compat_4b/ui-tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "step_counter_extension-ui-tests",
+  "version": "1.0.0",
+  "description": "JupyterLab step_counter_extension Integration Tests",
+  "private": true,
+  "scripts": {
+    "start": "jupyter lab --config jupyter_server_test_config.py",
+    "test": "jlpm playwright test",
+    "test:update": "jlpm playwright test --update-snapshots"
+  },
+  "devDependencies": {
+    "@jupyterlab/galata": "^5.0.5",
+    "@playwright/test": "^1.37.0"
+  }
+}

--- a/compat_4b/ui-tests/playwright.config.js
+++ b/compat_4b/ui-tests/playwright.config.js
@@ -1,0 +1,14 @@
+/**
+ * Configuration for Playwright using default from @jupyterlab/galata
+ */
+const baseConfig = require('@jupyterlab/galata/lib/playwright-config');
+
+module.exports = {
+  ...baseConfig,
+  webServer: {
+    command: 'jlpm start',
+    url: 'http://localhost:8888/lab',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI
+  }
+};

--- a/compat_4b/ui-tests/tests/step_counter_extension.spec.ts
+++ b/compat_4b/ui-tests/tests/step_counter_extension.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jupyterlab/galata';
+
+/**
+ * Don't load JupyterLab webpage before running the tests.
+ * This is required to ensure we capture all log messages.
+ */
+test.use({ autoGoto: false });
+
+test('should emit an activation console message', async ({ page }) => {
+  const logs: string[] = [];
+
+  page.on('console', message => {
+    logs.push(message.text());
+  });
+
+  await page.goto();
+
+  expect(
+    logs.filter(s => s === 'JupyterLab extension step_counter_extension is activated!')
+  ).toHaveLength(1);
+});

--- a/compat_4c/.copier-answers.yml
+++ b/compat_4c/.copier-answers.yml
@@ -1,0 +1,15 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+_commit: v4.2.0
+_src_path: https://github.com/jupyterlab/extension-template
+author_email: me@test.com
+author_name: My Name
+has_binder: false
+has_settings: false
+kind: frontend
+labextension_name: leap_counter_extension
+project_short_description: Adds a leap counter/button (1 of 3 related examples). This
+    extension holds the UI/interface.
+python_name: leap_counter_extension
+repository: ''
+test: true
+

--- a/compat_4c/.gitignore
+++ b/compat_4c/.gitignore
@@ -1,0 +1,125 @@
+*.bundle.*
+lib/
+node_modules/
+*.log
+.eslintcache
+.stylelintcache
+*.egg-info/
+.ipynb_checkpoints
+*.tsbuildinfo
+leap_counter_extension/labextension
+# Version file is handled by hatchling
+leap_counter_extension/_version.py
+
+# Integration tests
+ui-tests/test-results/
+ui-tests/playwright-report/
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage/
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python
+
+# OSX files
+.DS_Store
+
+# Yarn cache
+.yarn/

--- a/compat_4c/.prettierignore
+++ b/compat_4c/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+**/node_modules
+**/lib
+**/package.json
+!/package.json
+leap_counter_extension

--- a/compat_4c/.yarnrc.yml
+++ b/compat_4c/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/compat_4c/README.md
+++ b/compat_4c/README.md
@@ -1,0 +1,96 @@
+# leap_counter_extension
+
+[![Github Actions Status](/workflows/Build/badge.svg)](/actions/workflows/build.yml)
+Adds a leap counter/button (1 of 3 related examples). This extension holds the UI/interface.
+
+## Requirements
+
+- JupyterLab >= 4.0.0
+
+## Install
+
+To install the extension, execute:
+
+```bash
+pip install leap_counter_extension
+```
+
+## Uninstall
+
+To remove the extension, execute:
+
+```bash
+pip uninstall leap_counter_extension
+```
+
+## Contributing
+
+### Development install
+
+Note: You will need NodeJS to build the extension package.
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
+
+```bash
+# Clone the repo to your local environment
+# Change directory to the leap_counter_extension directory
+# Install package in development mode
+pip install -e "."
+# Link your development version of the extension with JupyterLab
+jupyter labextension develop . --overwrite
+# Rebuild extension Typescript source after making changes
+jlpm build
+```
+
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+
+```bash
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm watch
+# Run JupyterLab in another terminal
+jupyter lab
+```
+
+With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
+
+By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+
+```bash
+jupyter lab build --minimize=False
+```
+
+### Development uninstall
+
+```bash
+pip uninstall leap_counter_extension
+```
+
+In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
+command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
+folder is located. Then you can remove the symlink named `leap_counter_extension` within that folder.
+
+### Testing the extension
+
+#### Frontend tests
+
+This extension is using [Jest](https://jestjs.io/) for JavaScript code testing.
+
+To execute them, execute:
+
+```sh
+jlpm
+jlpm test
+```
+
+#### Integration tests
+
+This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
+More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
+
+More information are provided within the [ui-tests](./ui-tests/README.md) README.
+
+### Packaging the extension
+
+See [RELEASE](RELEASE.md)

--- a/compat_4c/babel.config.js
+++ b/compat_4c/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/compat_4c/install.json
+++ b/compat_4c/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "leap_counter_extension",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package leap_counter_extension"
+}

--- a/compat_4c/jest.config.js
+++ b/compat_4c/jest.config.js
@@ -1,0 +1,28 @@
+const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
+
+const esModules = [
+  '@codemirror',
+  '@jupyter/ydoc',
+  '@jupyterlab/',
+  'lib0',
+  'nanoid',
+  'vscode-ws-jsonrpc',
+  'y-protocols',
+  'y-websocket',
+  'yjs'
+].join('|');
+
+const baseConfig = jestJupyterLab(__dirname);
+
+module.exports = {
+  ...baseConfig,
+  automock: false,
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/.ipynb_checkpoints/*'
+  ],
+  coverageReporters: ['lcov', 'text'],
+  testRegex: 'src/.*/.*.spec.ts[x]?$',
+  transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`]
+};

--- a/compat_4c/leap_counter_extension/__init__.py
+++ b/compat_4c/leap_counter_extension/__init__.py
@@ -1,0 +1,16 @@
+try:
+    from ._version import __version__
+except ImportError:
+    # Fallback when using the package in dev mode without installing
+    # in editable mode with pip. It is highly recommended to install
+    # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
+    import warnings
+    warnings.warn("Importing 'leap_counter_extension' outside a proper installation.")
+    __version__ = "dev"
+
+
+def _jupyter_labextension_paths():
+    return [{
+        "src": "labextension",
+        "dest": "leap_counter_extension"
+    }]

--- a/compat_4c/package.json
+++ b/compat_4c/package.json
@@ -1,0 +1,203 @@
+{
+    "name": "leap_counter_extension",
+    "version": "0.1.0",
+    "description": "Adds a leap counter/button (1 of 3 related examples). This extension holds the UI/interface.",
+    "keywords": [
+        "jupyter",
+        "jupyterlab",
+        "jupyterlab-extension"
+    ],
+    "homepage": "",
+    "bugs": {
+        "url": "/issues"
+    },
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "My Name",
+        "email": "me@test.com"
+    },
+    "files": [
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    ],
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "style": "style/index.css",
+    "repository": {
+        "type": "git",
+        "url": ".git"
+    },
+    "workspaces": [
+        "ui-tests"
+    ],
+    "scripts": {
+        "build": "jlpm build:lib && jlpm build:labextension:dev",
+        "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
+        "build:labextension": "jupyter labextension build .",
+        "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:lib": "tsc --sourceMap",
+        "build:lib:prod": "tsc",
+        "clean": "jlpm clean:lib",
+        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+        "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+        "clean:labextension": "rimraf leap_counter_extension/labextension leap_counter_extension/_version.py",
+        "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "install:extension": "jlpm build",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+        "test": "jest --coverage",
+        "watch": "run-p watch:src watch:labextension",
+        "watch:src": "tsc -w --sourceMap",
+        "watch:labextension": "jupyter labextension watch ."
+    },
+    "dependencies": {
+        "@jupyterlab/application": "^4.0.0",
+        "@lumino/widgets": "^2.0.0",
+        "step_counter": "file:./../compat_4a"
+    },
+    "devDependencies": {
+        "@jupyterlab/builder": "^4.0.0",
+        "@jupyterlab/testutils": "^4.0.0",
+        "@types/jest": "^29.2.0",
+        "@types/json-schema": "^7.0.11",
+        "@types/react": "^18.0.26",
+        "@types/react-addons-linked-state-mixin": "^0.14.22",
+        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@typescript-eslint/parser": "^6.1.0",
+        "css-loader": "^6.7.1",
+        "eslint": "^8.36.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "jest": "^29.2.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^3.0.0",
+        "rimraf": "^5.0.1",
+        "source-map-loader": "^1.0.2",
+        "style-loader": "^3.3.1",
+        "stylelint": "^15.10.1",
+        "stylelint-config-recommended": "^13.0.0",
+        "stylelint-config-standard": "^34.0.0",
+        "stylelint-csstree-validator": "^3.0.0",
+        "stylelint-prettier": "^4.0.0",
+        "typescript": "~5.0.2",
+        "yjs": "^13.5.0"
+    },
+    "sideEffects": [
+        "style/*.css",
+        "style/index.js"
+    ],
+    "styleModule": "style/index.js",
+    "publishConfig": {
+        "access": "public"
+    },
+    "jupyterlab": {
+        "extension": true,
+        "outputDir": "leap_counter_extension/labextension",
+        "sharedPackages": {
+            "step_counter": {
+                "bundled": false,
+                "singleton": true
+            }
+        }
+    },
+    "eslintIgnore": [
+        "node_modules",
+        "dist",
+        "coverage",
+        "**/*.d.ts",
+        "tests",
+        "**/__tests__",
+        "ui-tests"
+    ],
+    "eslintConfig": {
+        "extends": [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended",
+            "plugin:prettier/recommended"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+            "project": "tsconfig.json",
+            "sourceType": "module"
+        },
+        "plugins": [
+            "@typescript-eslint"
+        ],
+        "rules": {
+            "@typescript-eslint/naming-convention": [
+                "error",
+                {
+                    "selector": "interface",
+                    "format": [
+                        "PascalCase"
+                    ],
+                    "custom": {
+                        "regex": "^I[A-Z]",
+                        "match": true
+                    }
+                }
+            ],
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    "args": "none"
+                }
+            ],
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-namespace": "off",
+            "@typescript-eslint/no-use-before-define": "off",
+            "@typescript-eslint/quotes": [
+                "error",
+                "single",
+                {
+                    "avoidEscape": true,
+                    "allowTemplateLiterals": false
+                }
+            ],
+            "curly": [
+                "error",
+                "all"
+            ],
+            "eqeqeq": "error",
+            "prefer-arrow-callback": "error"
+        }
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "avoid",
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
+    },
+    "stylelint": {
+        "extends": [
+            "stylelint-config-recommended",
+            "stylelint-config-standard",
+            "stylelint-prettier/recommended"
+        ],
+        "plugins": [
+            "stylelint-csstree-validator"
+        ],
+        "rules": {
+            "csstree/validator": true,
+            "property-no-vendor-prefix": null,
+            "selector-no-vendor-prefix": null,
+            "value-no-vendor-prefix": null
+        }
+    }
+}

--- a/compat_4c/pyproject.toml
+++ b/compat_4c/pyproject.toml
@@ -1,0 +1,76 @@
+[build-system]
+requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version"]
+build-backend = "hatchling.build"
+
+[project]
+name = "leap_counter_extension"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.8"
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+]
+dynamic = ["version", "description", "authors", "urls", "keywords"]
+
+[tool.hatch.version]
+source = "nodejs"
+
+[tool.hatch.metadata.hooks.nodejs]
+fields = ["description", "authors", "urls"]
+
+[tool.hatch.build.targets.sdist]
+artifacts = ["leap_counter_extension/labextension"]
+exclude = [".github", "binder"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"leap_counter_extension/labextension" = "share/jupyter/labextensions/leap_counter_extension"
+"install.json" = "share/jupyter/labextensions/leap_counter_extension/install.json"
+
+[tool.hatch.build.hooks.version]
+path = "leap_counter_extension/_version.py"
+
+[tool.hatch.build.hooks.jupyter-builder]
+dependencies = ["hatch-jupyter-builder>=0.5"]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = [
+    "leap_counter_extension/labextension/static/style.js",
+    "leap_counter_extension/labextension/package.json",
+]
+skip-if-exists = ["leap_counter_extension/labextension/static/style.js"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+build_cmd = "build:prod"
+npm = ["jlpm"]
+
+[tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
+build_cmd = "install:extension"
+npm = ["jlpm"]
+source_dir = "src"
+build_dir = "leap_counter_extension/labextension"
+
+[tool.jupyter-releaser.options]
+version_cmd = "hatch version"
+
+[tool.jupyter-releaser.hooks]
+before-build-npm = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "jlpm",
+    "jlpm build:prod"
+]
+before-build-python = ["jlpm clean:all"]
+
+[tool.check-wheel-contents]
+ignore = ["W002"]

--- a/compat_4c/setup.py
+++ b/compat_4c/setup.py
@@ -1,0 +1,1 @@
+__import__("setuptools").setup()

--- a/compat_4c/src/__tests__/leap_counter_extension.spec.ts
+++ b/compat_4c/src/__tests__/leap_counter_extension.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
+ */
+
+describe('leap_counter_extension', () => {
+  it('should be tested', () => {
+    expect(1 + 1).toEqual(2);
+  });
+});

--- a/compat_4c/src/index.ts
+++ b/compat_4c/src/index.ts
@@ -1,0 +1,111 @@
+// This is one of three related extension examples that demonstrate
+// JupyterLab's provider-consumer pattern, where plugins can depend
+// on and reuse features from one another. The three packages that
+// make up the complete example are:
+//
+//   1. The step_counter package. This package holds a token, a
+//      class + an interface that make up a stock implementation of
+//      the "step_counter" service, and a provider plugin that
+//      makes an instance of the Counter available to JupyterLab
+//      as a service object.
+//   2. The step_counter_extension package, that holds a
+//      UI/interface in JupyterLab for users to count their steps that
+//      connects with/consumes the step_counter service object via a
+//      consumer plugin.
+//   3. (*) The leap_counter_extension package (this one), that holds an alternate
+//      way for users to count steps (a leap is 5 steps). Like the step_counter_extension
+//      package, this holds a UI/interface in JupyterLab, and a consumer
+//      plugin that also requests/consumes the step_counter service
+//      object. The leap_counter_extension package demonstrates how
+//      an unrelated plugin can depend on and reuse features from
+//      an existing plugin. Users can install either the
+//      step_counter_extension, the leap_counter_extension or both
+//      to get whichever features they prefer (with both reusing
+//      the step_counter service object).
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { Widget } from '@lumino/widgets';
+
+import { StepCounter} from "step_counter";
+
+// This widget holds the JupyterLab UI/interface that users will
+// see and interact with to count and view their steps.
+class LeapCounterWidget extends Widget {
+
+  leapButton: HTMLElement;
+  combinedStepCountLabel: HTMLElement;
+  counter: any;
+
+  // Notice that the constructor for this object takes a "counter"
+  // argument, which is the service object associated with the StepCounter
+  // token (which is passed in by the consumer plugin).
+  constructor(counter: any) {
+    super();
+
+    this.counter = counter;
+
+    // Add styling by using a CSS class
+    this.node.classList.add('jp-leap-container');
+
+    // Create and add a button to this widget's root node
+    const leapButton = document.createElement('div');
+    leapButton.innerText = 'Take a Leap';
+    // Add a listener to handle button clicks
+    leapButton.addEventListener('click', this.takeLeap.bind(this));
+    leapButton.classList.add('jp-leap-button');
+    this.node.appendChild(leapButton);
+    this.leapButton = leapButton;
+
+    // Add a label to display the step count
+    const combinedStepCountLabel = document.createElement('p');
+    combinedStepCountLabel.classList.add('jp-combined-step-count-label');
+    this.node.appendChild(combinedStepCountLabel);
+    this.combinedStepCountLabel = combinedStepCountLabel;
+
+    this.updateStepCountDisplay();
+  }
+
+  // Refresh the displayed step count
+  updateStepCountDisplay() {
+    this.combinedStepCountLabel.innerText = 'Combined Step Count: ' + this.counter.getStepCount();
+  }
+
+  // Increment the step count, a leap is 5 steps
+  takeLeap() {
+    this.counter.incrementStepCount(5);
+    this.updateStepCountDisplay();
+  }
+}
+
+// This plugin is a "consumer" in JupyterLab's provider-consumer pattern.
+// The "requires" property of this plugin lists the StepCounter token, which
+// requests the service-object associated with that token from JupyterLab,
+// and this plugin "consumes" the service object by using it in its own code.
+// Whenever you add a "requires" or "optional" service, you need to manually
+// add an argument to your plugin's "activate" function.
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'leap_counter_extension:plugin',
+  description: 'Adds a leap counter/button (1 of 3 related examples). This extension holds the UI/interface',
+  autoStart: true,
+  requires: [StepCounter],
+  // The activate function here will be called by JupyterLab when the plugin loads.
+  // When JupyterLab calls your plugin's activate function, it will always pass
+  // an application as the first argument, then any required arguments, then any optional
+  // arguments, so make sure you add arguments for those here when your plugin requests
+  // any required or optional services. If a required service is missing, your plugin
+  // won't load. If an optional service is missing, the supplied argument will be null.
+  activate: (app: JupyterFrontEnd, counter: any) => {
+    console.log('JupyterLab extension leap_counter_extension is activated!');
+
+    // Create a LeapCounterWidget and add it to the interface
+    const leapWidget: LeapCounterWidget = new LeapCounterWidget(counter);
+    leapWidget.id = 'JupyterLeapWidget';  // Widgets need an id
+    app.shell.add(leapWidget, 'top');
+  }
+};
+
+export default plugin;

--- a/compat_4c/style/base.css
+++ b/compat_4c/style/base.css
@@ -1,0 +1,28 @@
+/*
+    See the JupyterLab Developer Guide for useful CSS Patterns:
+
+    https://jupyterlab.readthedocs.io/en/stable/developer/css.html
+*/
+
+.jp-leap-container {
+    display: inline;
+    user-select: none;
+}
+
+.jp-leap-button {
+    width: 85px;
+    margin: 4px;
+    padding: 2px;
+    text-align: center;
+    vertical-align: middle;
+    border-radius: 2px;
+    background-color: #00eb00;
+    color: #212121;
+    display: inline-block;
+}
+
+.jp-combined-step-count-label {
+    display: inline-block;
+    margin: 6px;
+    vertical-align: middle;
+}

--- a/compat_4c/style/index.css
+++ b/compat_4c/style/index.css
@@ -1,0 +1,1 @@
+@import url('base.css');

--- a/compat_4c/style/index.js
+++ b/compat_4c/style/index.js
@@ -1,0 +1,1 @@
+import './base.css';

--- a/compat_4c/tsconfig.json
+++ b/compat_4c/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "ES2018"
+  },
+  "include": ["src/*"]
+}

--- a/compat_4c/tsconfig.test.json
+++ b/compat_4c/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "types": ["jest"]
+  }
+}

--- a/compat_4c/ui-tests/README.md
+++ b/compat_4c/ui-tests/README.md
@@ -1,0 +1,167 @@
+# Integration Testing
+
+This folder contains the integration tests of the extension.
+
+They are defined using [Playwright](https://playwright.dev/docs/intro) test runner
+and [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) helper.
+
+The Playwright configuration is defined in [playwright.config.js](./playwright.config.js).
+
+The JupyterLab server configuration to use for the integration test is defined
+in [jupyter_server_test_config.py](./jupyter_server_test_config.py).
+
+The default configuration will produce video for failing tests and an HTML report.
+
+> There is a new experimental UI mode that you may fall in love with; see [that video](https://www.youtube.com/watch?v=jF0yA-JLQW0).
+
+## Run the tests
+
+> All commands are assumed to be executed from the root directory
+
+To run the tests, you need to:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the [Playwright](https://playwright.dev/docs/intro) tests:
+
+```sh
+cd ./ui-tests
+jlpm playwright test
+```
+
+Test results will be shown in the terminal. In case of any test failures, the test report
+will be opened in your browser at the end of the tests execution; see
+[Playwright documentation](https://playwright.dev/docs/test-reporters#html-reporter)
+for configuring that behavior.
+
+## Update the tests snapshots
+
+> All commands are assumed to be executed from the root directory
+
+If you are comparing snapshots to validate your tests, you may need to update
+the reference snapshots stored in the repository. To do that, you need to:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the [Playwright](https://playwright.dev/docs/intro) command:
+
+```sh
+cd ./ui-tests
+jlpm playwright test -u
+```
+
+> Some discrepancy may occurs between the snapshots generated on your computer and
+> the one generated on the CI. To ease updating the snapshots on a PR, you can
+> type `please update playwright snapshots` to trigger the update by a bot on the CI.
+> Once the bot has computed new snapshots, it will commit them to the PR branch.
+
+## Create tests
+
+> All commands are assumed to be executed from the root directory
+
+To create tests, the easiest way is to use the code generator tool of playwright:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Start the server:
+
+```sh
+cd ./ui-tests
+jlpm start
+```
+
+4. Execute the [Playwright code generator](https://playwright.dev/docs/codegen) in **another terminal**:
+
+```sh
+cd ./ui-tests
+jlpm playwright codegen localhost:8888
+```
+
+## Debug tests
+
+> All commands are assumed to be executed from the root directory
+
+To debug tests, a good way is to use the inspector tool of playwright:
+
+1. Compile the extension:
+
+```sh
+jlpm install
+jlpm build:prod
+```
+
+> Check the extension is installed in JupyterLab.
+
+2. Install test dependencies (needed only once):
+
+```sh
+cd ./ui-tests
+jlpm install
+jlpm playwright install
+cd ..
+```
+
+3. Execute the Playwright tests in [debug mode](https://playwright.dev/docs/debug):
+
+```sh
+cd ./ui-tests
+jlpm playwright test --debug
+```
+
+## Upgrade Playwright and the browsers
+
+To update the web browser versions, you must update the package `@playwright/test`:
+
+```sh
+cd ./ui-tests
+jlpm up "@playwright/test"
+jlpm playwright install
+```

--- a/compat_4c/ui-tests/jupyter_server_test_config.py
+++ b/compat_4c/ui-tests/jupyter_server_test_config.py
@@ -1,0 +1,12 @@
+"""Server configuration for integration tests.
+
+!! Never use this configuration in production because it
+opens the server to the world and provide access to JupyterLab
+JavaScript objects through the global window variable.
+"""
+from jupyterlab.galata import configure_jupyter_server
+
+configure_jupyter_server(c)
+
+# Uncomment to set server log level to debug level
+# c.ServerApp.log_level = "DEBUG"

--- a/compat_4c/ui-tests/package.json
+++ b/compat_4c/ui-tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "leap_counter_extension-ui-tests",
+  "version": "1.0.0",
+  "description": "JupyterLab leap_counter_extension Integration Tests",
+  "private": true,
+  "scripts": {
+    "start": "jupyter lab --config jupyter_server_test_config.py",
+    "test": "jlpm playwright test",
+    "test:update": "jlpm playwright test --update-snapshots"
+  },
+  "devDependencies": {
+    "@jupyterlab/galata": "^5.0.5",
+    "@playwright/test": "^1.37.0"
+  }
+}

--- a/compat_4c/ui-tests/playwright.config.js
+++ b/compat_4c/ui-tests/playwright.config.js
@@ -1,0 +1,14 @@
+/**
+ * Configuration for Playwright using default from @jupyterlab/galata
+ */
+const baseConfig = require('@jupyterlab/galata/lib/playwright-config');
+
+module.exports = {
+  ...baseConfig,
+  webServer: {
+    command: 'jlpm start',
+    url: 'http://localhost:8888/lab',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI
+  }
+};

--- a/compat_4c/ui-tests/tests/leap_counter_extension.spec.ts
+++ b/compat_4c/ui-tests/tests/leap_counter_extension.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jupyterlab/galata';
+
+/**
+ * Don't load JupyterLab webpage before running the tests.
+ * This is required to ensure we capture all log messages.
+ */
+test.use({ autoGoto: false });
+
+test('should emit an activation console message', async ({ page }) => {
+  const logs: string[] = [];
+
+  page.on('console', message => {
+    logs.push(message.text());
+  });
+
+  await page.goto();
+
+  expect(
+    logs.filter(s => s === 'JupyterLab extension leap_counter_extension is activated!')
+  ).toHaveLength(1);
+});


### PR DESCRIPTION
This example adds three related extension packages: compat_4a, compat_4b and compat_4c (renaming is TODO). With all 3 installed in a JupyterLab environment, users will get a provider extension that counts steps, and two alternate consumer plugins that consume the provider's step_counter service. One semi trivial `TODO` remains to add Lumino signals so that the display labels for each plugin update on step count increment.