### PR TITLE
Update copier command (copier 7.2->9.2)

### DIFF
--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -14,7 +14,7 @@ Writing a JupyterLab extension usually starts from a configurable template. It
 can be downloaded with the [`copier`](https://copier.readthedocs.io/) tool and the following command:
 
 ```bash
-pip install "copier~=7.2" jinja2-time "pydantic<2.0.0"
+pip install "copier~=9.2" jinja2-time "pydantic<2.0.0"
 mkdir my_extension
 cd my_extension
 copier copy https://github.com/jupyterlab/extension-template .

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -14,7 +14,7 @@ Writing a JupyterLab extension usually starts from a configurable template. It
 can be downloaded with the [`copier`](https://copier.readthedocs.io/) tool and the following command:
 
 ```bash
-pip install "copier~=9.2" jinja2-time "pydantic<2.0.0"
+pip install "copier~=9.2" jinja2-time
 mkdir my_extension
 cd my_extension
 copier copy https://github.com/jupyterlab/extension-template .

--- a/mimerenderer/README.md
+++ b/mimerenderer/README.md
@@ -26,7 +26,7 @@ You will initialize the extension by using [copier](https://copier.readthedocs.i
 Execute the following commands in your terminal:
 
 ```bash
-pip install copier jinja2-time
+pip install "copier~=9.2" jinja2-time
 mkdir my_mimerenderer
 cd my_mimerenderer
 copier copy --trust https://github.com/jupyterlab/extension-template .

--- a/mimerenderer/README.md
+++ b/mimerenderer/README.md
@@ -29,7 +29,7 @@ Execute the following commands in your terminal:
 pip install copier jinja2-time
 mkdir my_mimerenderer
 cd my_mimerenderer
-copier https://github.com/jupyterlab/extension-template .
+copier copy --trust https://github.com/jupyterlab/extension-template .
 ```
 
 You will be asked for some basic information that could for example be setup

--- a/server-extension/README.md
+++ b/server-extension/README.md
@@ -22,7 +22,7 @@ Writing a JupyterLab extension usually starts from a configurable template. It
 can be downloaded with the [`copier`](https://copier.readthedocs.io/) tool and the following command for an extension with a server part:
 
 ```bash
-pip install copier jinja2-time
+pip install "copier~=9.2" jinja2-time
 mkdir my_extension
 cd my_extension
 copier copy --trust https://github.com/jupyterlab/extension-template .

--- a/server-extension/README.md
+++ b/server-extension/README.md
@@ -25,7 +25,7 @@ can be downloaded with the [`copier`](https://copier.readthedocs.io/) tool and t
 pip install copier jinja2-time
 mkdir my_extension
 cd my_extension
-copier https://github.com/jupyterlab/extension-template .
+copier copy --trust https://github.com/jupyterlab/extension-template .
 ```
 
 You will be asked for some basic information that could for example be setup


### PR DESCRIPTION
Fixes: https://github.com/jupyterlab/extension-examples/issues/270

Bring copier command into line with copier versions used in template repo.